### PR TITLE
docs: correct demo crawl limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Este passo só é necessário para popular o banco de dados pela primeira vez a 
 python main.py
 ```
 
+Para um teste rápido, execute `python main.py --demo` e o crawler irá coletar apenas 5 páginas.
+
 Este comando irá executar os scripts de extração e processamento, criando o arquivo `output/prompts_database_final.json`.
 
 #### 2\. Gerenciamento e Visualização (Painel de Administração)

--- a/main.py
+++ b/main.py
@@ -38,14 +38,14 @@ def run_script(script_name, is_demo_mode):
 def main():
     """
     Orquestra a execução de todo o pipeline.
-    Execute com 'python main.py --demo' para um teste rápido com 20 páginas.
+    Execute com 'python main.py --demo' para um teste rápido com 5 páginas.
     Execute com 'python main.py' para o processo completo.
     """
     # Verifica se o modo demo foi ativado através dos argumentos da linha de comando
     is_demo_mode = '--demo' in sys.argv
 
     if is_demo_mode:
-        print(">>> INICIANDO O PIPELINE EM MODO DEMO (LIMITE DE 20 PÁGINAS) <<<")
+        print(">>> INICIANDO O PIPELINE EM MODO DEMO (LIMITE DE 5 PÁGINAS) <<<")
     else:
         print(">>> INICIANDO O PIPELINE COMPLETO <<<")
     


### PR DESCRIPTION
## Summary
- adjust main.py to document 5-page demo limit
- document quick demo mode in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d2e6c430832db56b160722b57136